### PR TITLE
Stop reformatting paon

### DIFF
--- a/lib/property_data.rb
+++ b/lib/property_data.rb
@@ -59,18 +59,15 @@ class PropertyData
   end
 
   def format_address(property_json)
-    saon = property_json["saon"]
-    paon_street = ["paon", "street"].map do |key|
-      property_json[key]
-    end.compact.join(" ")
+    saon = capitalise_if_exists(property_json["saon"])
+    paon = property_json["paon"]
+    street = capitalise_if_exists(property_json["street"])
+    paon_street = [paon, street].compact.join(" ")
     rest_of_address = ["town", "county"].map do |key|
-      property_json[key]
+      capitalise_if_exists(property_json[key])
     end
     address_lines = ([saon, paon_street] + rest_of_address).compact
-    capitalised_lines = address_lines.map do |address_line|
-      NameCase(address_line)
-    end
-    capitalised_lines + [property_json["postcode"]]
+    address_lines + [property_json["postcode"]]
   end
 
   def format_ppi(property_json)
@@ -81,6 +78,10 @@ class PropertyData
     else
       unavailable_data
     end
+  end
+
+  def capitalise_if_exists(string)
+    NameCase(string) if string
   end
 
 end

--- a/spec/property_data_spec.rb
+++ b/spec/property_data_spec.rb
@@ -28,7 +28,8 @@ describe PropertyData do
 
   let(:complicated_caps) {
     {
-      "street" => "53 MCDONALDS O'BRIEN VON STREIT MACDONALDS DE LA TOUR DI CAPRIO ST. JOHN STREET",
+      "paon" => "2D",
+      "street" => "MCDONALDS O'BRIEN VON STREIT MACDONALDS DE LA TOUR DI CAPRIO ST. JOHN STREET",
       "town" => "PLYMOUTH",
       "postcode" => "PL3 7TH"
     }
@@ -127,7 +128,7 @@ describe PropertyData do
       result = property_data.find(postcode, address_string)
       expect(result[:address]).to eq(
         [
-          "53 McDonalds O'Brien von Streit MacDonalds de la Tour di Caprio St. John Street",
+          "2D McDonalds O'Brien von Streit MacDonalds de la Tour di Caprio St. John Street",
           "Plymouth",
           "PL3 7TH"
         ]

--- a/test/controllers/properties_controller_test.rb
+++ b/test/controllers/properties_controller_test.rb
@@ -8,7 +8,7 @@ class PropertiesControllerTest < ActionController::TestCase
       assert_response :success
       assert_template :application
       property = assigns(:property)
-      assert_equal ["Saon Goes Here", "Paon Goes Here Street Goes Here", "Town Goes Here", "County Goes Here", "postcode goes here"], property[:address]
+      assert_equal ["Saon Goes Here", "paon goes here Street Goes Here", "Town Goes Here", "County Goes Here", "postcode goes here"], property[:address]
       assert_equal "Terraced", property[:property_type]
       assert_equal "£107,500 on 30 September 2010", property[:price_paid_info]
       assert_equal 99, property[:coordinates][:latitude]


### PR DESCRIPTION
Small change to capitalisation logic to handle this type of edge case:
![screen shot 2015-02-17 at 11 24 59](https://cloud.githubusercontent.com/assets/5455804/6227429/a82c4354-b697-11e4-8e94-527c663557dd.png)
